### PR TITLE
Update zig to v0.11.0, add github actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+---
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    env:
+      CI: true
+      HOMEBREW_NO_INSTALL_CLEANUP: true
+      DEBIAN_FRONTEND: noninteractive
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          # - windows-latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install rake
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: false
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.11.0-dev.3289+16dbb960f
+
+      - name: Lint
+        run: zig fmt --check src/*.zig && echo "OK"
+
+      - name: Build
+        run: |
+          zig build -fsummary -Doptimize=ReleaseSafe
+          file ./zig-out/bin/*
+          du -hs ./zig-out/bin/*
+
+      - name: Test
+        run: zig build test -fsummary

--- a/README.md
+++ b/README.md
@@ -14,16 +14,25 @@ recursively clone this repository and add a couple of lines to your
 
 - Add the following lines to `build.zig`, with the paths changed to match the correct location
 
-  ```zig
-  const addMruby = @import("mruby-zig/build.zig").addMruby;
+```zig
+const addMruby = @import("mruby-zig/build.zig").addMruby;
 
-  pub fn build(b: *std.build.Builder) void {
-      [...]
-      const exe = b.addExecutable("example", "src/main.zig");
-      addMruby(exe);
-      [...]
-  }
-  ```
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "example",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(exe);
+    addMruby(b, exe);
+
+    // ...
+}
+```
 
 - Import `mruby` and start a new interpreter
 

--- a/build.zig
+++ b/build.zig
@@ -1,25 +1,22 @@
 const std = @import("std");
 const path = std.fs.path;
 
-pub fn build(b: *std.build.Builder) void {
-    // Standard target options allows the person running `zig build` to choose
-    // what target to build for. Here we do not override the defaults, which
-    // means any target is allowed, and the default is native. Other options
-    // for restricting supported target set are available.
-    var target = b.standardTargetOptions(.{});
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+    const exe = b.addExecutable(.{
+        .name = "mruby-zig",
+        .root_source_file = .{ .path = "examples/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(exe);
+    addMruby(b, exe);
 
-    const exe = b.addExecutable("mruby-zig", "examples/main.zig");
-    exe.setTarget(target);
-    exe.setBuildMode(mode);
-    addMruby(exe);
-    exe.install();
-
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
+
     if (b.args) |args| {
         run_cmd.addArgs(args);
     }
@@ -27,28 +24,21 @@ pub fn build(b: *std.build.Builder) void {
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    const exe_tests = b.addTest("examples/main.zig");
-    exe_tests.setTarget(target);
-    exe_tests.setBuildMode(mode);
-    addMruby(exe_tests);
+    const unit_tests = b.addTest(.{
+        .root_source_file = .{ .path = "examples/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    addMruby(b, unit_tests);
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
 
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&exe_tests.step);
+    test_step.dependOn(&run_unit_tests.step);
 }
 
-pub fn addMruby(exe: *std.build.LibExeObjStep) void {
-    // Won't compile on my macbook without this
-    // zig version 0.10.0-dev.934+acec06cfa
-    // fails with the following error:
-    //     error(compilation): clang failed with stderr: In file included from /Users/dante/src/github.com/dantecatalfamo/mruby-zig/src/mruby_compat.c:4:
-    //     In file included from /Users/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/include/mruby.h:117:
-    //     /Users/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/include/mruby/value.h:426:10: fatal error: 'mach-o/getsect.h' file not found
-    if (exe.target.isDarwin()) {
-        exe.addFrameworkPath("/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk");
-    }
-    var allocator = exe.builder.allocator;
-
-    var build_mruby_step = BuildMrubyStep.init(exe.builder);
+pub fn addMruby(owner: *std.Build, exe: *std.Build.Step.Compile) void {
+    const allocator = owner.allocator;
 
     const src_dir = path.dirname(@src().file) orelse ".";
     const mruby_path = path.join(allocator, &.{ src_dir, "mruby" }) catch unreachable;
@@ -62,66 +52,20 @@ pub fn addMruby(exe: *std.build.LibExeObjStep) void {
     exe.linkSystemLibrary("mruby");
     exe.linkLibC();
     exe.addCSourceFile(compat_path, &.{});
-    exe.addPackagePath("mruby", package_path);
-    exe.step.dependOn(&build_mruby_step.step);
+
+    const mod = owner.createModule(.{
+        .source_file = .{ .path = package_path },
+    });
+    exe.addModule("mruby", mod);
+
+    const build_mruby = owner.addSystemCommand(&[_][]const u8{
+        "rake",
+        "--verbose",
+        "--directory",
+        mruby_path,
+        "CC=zig cc",
+        "CXX=zig c++",
+        "AR=zig ar",
+    });
+    exe.step.dependOn(&build_mruby.step);
 }
-
-pub const BuildMrubyStep = struct {
-    step: std.build.Step,
-    builder: *std.build.Builder,
-
-    pub fn init(builder: *std.build.Builder) *BuildMrubyStep {
-        const self = builder.allocator.create(BuildMrubyStep) catch unreachable;
-        self.* = BuildMrubyStep {
-            .builder = builder,
-            .step = std.build.Step.init(.custom, "build mruby", builder.allocator, make),
-        };
-        return self;
-    }
-
-    fn make(step: *std.build.Step) !void {
-        const self = @fieldParentPtr(BuildMrubyStep, "step", step);
-        const src_dir = path.dirname(@src().file) orelse ".";
-        const mruby_path = path.join(self.builder.allocator, &.{ src_dir, "mruby" }) catch unreachable;
-        try std.os.chdir(mruby_path);
-        // Use `zig cc` to compile code for consistency.
-        // `-ffast-math` used to avoid strange complex number compilation error
-        //
-        // [mruby-zig]$ zig build
-        // mkdir -p /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/build/host/bin
-        // LD    build/host/bin/mirb
-        // zig cc -target x86_64-linux-gnu  -o "/home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/build/host/bin/mirb" "/home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/build/host/mrbgems/mruby-bin-mirb/tools/mirb/mirb.o" "/home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/build/host/lib/libmruby.a"  -lm
-        // LLD Link... ld.lld: error: undefined symbol: __divdc3
-        // >>> referenced by cmath.c:162 (mrbgems/mruby-cmath/src/cmath.c:162)
-        // >>>               cmath.o:(cmath_log) in archive /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/build/host/lib/libmruby.a
-        // >>> did you mean: __divdf3
-        // >>> defined in: /home/dante/.cache/zig/o/a4bd34886613d2e269c83a864437187f/libcompiler_rt.a(/home/dante/.cache/zig/o/a4bd34886613d2e269c83a864437187f/compiler_rt.o)
-        // rake aborted!
-        // Command failed with status (1): [zig cc -target x86_64-linux-gnu  -o "/home...]
-        // /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/lib/mruby/build/command.rb:37:in `_run'
-        // /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/lib/mruby/build/command.rb:217:in `run'
-        // /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/tasks/bin.rake:17:in `block (4 levels) in <top (required)>'
-        // /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/Rakefile:42:in `block in <top (required)>'
-        // Tasks: TOP => build => /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/bin/mirb => /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/build/host/bin/mirb
-        // (See full trace by running task with --trace)
-        // LLD Link... ld.lld: error: undefined symbol: __divdc3
-        // >>> referenced by cmath.c:162 (mrbgems/mruby-cmath/src/cmath.c:162)
-        // >>>               cmath.o:(cmath_log) in archive /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/build/host/lib/libmruby.a
-        // >>> did you mean: __divdf3
-        // >>> defined in: /home/dante/.cache/zig/o/83760f4c975d893977be512204091f81/libcompiler_rt.a(/home/dante/.cache/zig/o/83760f4c975d893977be512204091f81/compiler_rt.o)
-        // error: LLDReportedFailure
-        // mruby-zig...The following command exited with error code 1:
-        // /home/dante/.asdf/installs/zig/master/zig build-exe /home/dante/src/github.com/dantecatalfamo/mruby-zig/examples/main.zig -lmruby -lc /home/dante/src/github.com/dantecatalfamo/mruby-zig/src/mruby_compat.c --cache-dir /home/dante/src/github.com/dantecatalfamo/mruby-zig/zig-cache --global-cache-dir /home/dante/.cache/zig --name mruby-zig -target native-native-gnu -mcpu=skylake+sgx --pkg-begin mruby /home/dante/src/github.com/dantecatalfamo/mruby-zig/src/mruby.zig --pkg-end -isystem /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/include -L /home/dante/src/github.com/dantecatalfamo/mruby-zig/mruby/build/host/lib --enable-cache
-        // error: the following build command failed with exit code 1:
-        // /home/dante/src/github.com/dantecatalfamo/mruby-zig/zig-cache/o/ea89ac36fa5fcd5b5e7bec7d5258adf6/build /home/dante/.asdf/installs/zig/master/zig /home/dante/src/github.com/dantecatalfamo/mruby-zig /home/dante/src/github.com/dantecatalfamo/mruby-zig/zig-cache /home/dante/.cache/zig
-        //
-        // If `-ffast-math` is passed in through CFLAGS it still
-        // produces the error, but not when as a part of CC. ¯\_(ツ)_/¯
-        //
-        // Related issue: https://github.com/ziglang/zig/issues/9259
-        // StackOverflow:  https://stackoverflow.com/questions/49438158/why-is-muldc3-called-when-two-stdcomplex-are-multiplied
-        var process = std.ChildProcess.init(&.{"rake", "CC=zig cc -ffast-math", "AR=zig ar", "--verbose"}, self.builder.allocator);
-        _ = try process.spawnAndWait();
-        try std.os.chdir("..");
-    }
-};

--- a/examples/main.zig
+++ b/examples/main.zig
@@ -39,15 +39,15 @@ pub fn main() anyerror!void {
 
     // Calling ruby methods from zig
     _ = mrb.funcall(kval, "zigfunc", .{});
-    _ = mrb.funcall(kval, "puts", .{ mrb.str_new_lit("hello from puts called in zig!") });
-    _ = mrb.funcall(kval, "puts", .{ mrb.int_value(1337) });
+    _ = mrb.funcall(kval, "puts", .{mrb.str_new_lit("hello from puts called in zig!")});
+    _ = mrb.funcall(kval, "puts", .{mrb.int_value(1337)});
 
     // Freezing objects
     const strf = mrb.str_new("this is a string");
-    std.log.debug("string frozen? {}", .{ strf.frozen_p() });
+    std.log.debug("string frozen? {}", .{strf.frozen_p()});
     try strf.freeze();
     std.log.debug("freezing string", .{});
-    std.log.debug("string frozen? {}", .{ strf.frozen_p() });
+    std.log.debug("string frozen? {}", .{strf.frozen_p()});
 
     // Custom class
     const fancy_class = try mrb.define_class("FancyClass", mrb.object_class());
@@ -69,7 +69,7 @@ pub fn main() anyerror!void {
 
     // Get and set instance variables
     const boring_class = try mrb.define_class("BoringClass", null);
-    mrb.define_method(boring_class, "set_var", boringClassSetVar, .{ .req = 1});
+    mrb.define_method(boring_class, "set_var", boringClassSetVar, .{ .req = 1 });
     mrb.define_method(boring_class, "get_var", boringClassGetVar, .{});
 
     // Dollar store repl
@@ -103,9 +103,9 @@ export fn zigInRuby(mrb: *mruby.mrb_state, self: mruby.mrb_value) mruby.mrb_valu
 export fn zigOneArg(mrb: *mruby.mrb_state, self: mruby.mrb_value) mruby.mrb_value {
     const arg = mrb.get_arg1();
     if (arg.integer_p()) {
-        std.log.debug("Received integer: {d}", .{ arg.integer() catch unreachable });
+        std.log.debug("Received integer: {d}", .{arg.integer() catch unreachable});
     } else {
-        std.log.debug("Received type: {}", .{ arg.vType() });
+        std.log.debug("Received type: {}", .{arg.vType()});
     }
     return self;
 }
@@ -125,7 +125,7 @@ pub const DataType = struct {
     allocator: std.mem.Allocator,
 };
 
-const data_type_descriptor = mruby.mrb_data_type {
+const data_type_descriptor = mruby.mrb_data_type{
     .struct_name = "zigDataType",
     .dfree = dataTypeFree,
 };
@@ -146,7 +146,7 @@ pub export fn dataTypeGetInt(mrb: *mruby.mrb_state, self: mruby.mrb_value) mruby
 
 pub export fn dataTypeSetInt(mrb: *mruby.mrb_state, self: mruby.mrb_value) mruby.mrb_value {
     var int: i64 = undefined;
-    _ = mrb.get_args("i", .{ &int });
+    _ = mrb.get_args("i", .{&int});
     const rawptr = mrb.data_get_ptr(self, &data_type_descriptor);
     const ptr = @ptrCast(*DataType, @alignCast(@alignOf(DataType), rawptr));
     ptr.int = int;

--- a/examples/main.zig
+++ b/examples/main.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-// const mruby = @import("../src/mruby.zig");
 const mruby = @import("mruby");
 
 pub fn main() anyerror!void {

--- a/src/mruby.zig
+++ b/src/mruby.zig
@@ -804,7 +804,7 @@ pub const mrb_state = opaque {
     /// @see mrb_args_format
     /// @see mrb_kwargs
     pub fn get_args(self: *Self, fmt: mrb_args_format, args: anytype) mrb_int {
-        return @call(.{}, mrb_get_args, .{ self, fmt } ++ args);
+        return @call(.auto, mrb_get_args, .{ self, fmt } ++ args);
     }
 
     /// get method symbol
@@ -869,10 +869,10 @@ pub const mrb_state = opaque {
     /// @param ... Variadic values(not type safe!).
     /// @return [mrb_value] mruby function value.
     pub fn funcall(self: *Self, obj: mrb_value, method: [*:0]const u8, args: anytype) mrb_value {
-        return @call(.{}, mrb_funcall, .{ self, obj, method, args.len } ++ args);
+        return @call(.auto, mrb_funcall, .{ self, obj, method, args.len } ++ args);
     }
     pub fn funcall_id(self: *Self, obj: mrb_value, mid: mrb_sym, args: anytype) mrb_value {
-        return @call(.{}, mrb_funcall_id, .{ self, obj, mid, args.len } ++ args);
+        return @call(.auto, mrb_funcall_id, .{ self, obj, mid, args.len } ++ args);
     }
 
     /// Call existing ruby functions. This is basically the type safe version of mrb_funcall.
@@ -1175,10 +1175,10 @@ pub const mrb_state = opaque {
         return mrb_raise(self, cla, msg);
     }
     pub fn raisef(self: *Self, cla: *RClass, fmt: [*:0]const u8, args: anytype) mrb_noreturn {
-        return @call(.{}, mrb_raisef, .{ self, cla, fmt } ++ args);
+        return @call(.auto, mrb_raisef, .{ self, cla, fmt } ++ args);
     }
     pub fn name_error(self: *Self, id: mrb_sym, fmt: [*:0]const u8, args: anytype) mrb_noreturn {
-        return @call(.{}, mrb_name_error, .{ self, id, fmt } ++ args);
+        return @call(.auto, mrb_name_error, .{ self, id, fmt } ++ args);
     }
     pub fn frozen_error(self: *Self, frozen_obj: *anyopaque) mrb_noreturn {
         return mrb_frozen_error(self, frozen_obj);
@@ -1187,10 +1187,10 @@ pub const mrb_state = opaque {
         return mrb_argnum_error(self, argc, min, max);
     }
     pub fn warn(self: *Self, fmt: [*:0]const u8, args: anytype) void {
-        return @call(.{}, mrb_warn, .{ self, fmt } ++ args );
+        return @call(.auto, mrb_warn, .{ self, fmt } ++ args);
     }
     pub fn bug(self: *Self, fmt: [*:0]const u8, args: anytype) mrb_noreturn {
-        return @call(.{}, mrb_bug, .{ self, fmt } ++ args);
+        return @call(.auto, mrb_bug, .{ self, fmt } ++ args);
     }
     pub fn print_backtrace(self: *Self) void {
         return mrb_print_backtrace(self);
@@ -1331,7 +1331,7 @@ pub const mrb_state = opaque {
     }
 
     pub fn format(self: *Self, fmt: [*:0]const u8, args: anytype) mrb_value {
-        return @call(.{}, mrb_format, .{ self, fmt } ++ args);
+        return @call(.auto, mrb_format, .{ self, fmt } ++ args);
     }
 
     // mruby/array.h
@@ -1803,7 +1803,7 @@ pub const mrb_state = opaque {
         return mrb_get_backtrace(self);
     }
     pub fn no_method_error(self: *Self, id: mrb_sym, args: mrb_value, fmt: [*:0]const u8, vars: anytype) mrb_noreturn {
-        return @call(.{}, mrb_no_method_error, .{ self, id, args, fmt } ++ vars);
+        return @call(.auto, mrb_no_method_error, .{ self, id, args, fmt } ++ vars);
     }
     pub fn f_raise(self: *Self, value: mrb_value) mrb_value {
         return mrb_f_raise(self, value);
@@ -3978,7 +3978,7 @@ pub const mrbc_context = opaque {};
 pub extern fn mrbc_context_new(mrb: *mrb_state) ?*mrbc_context;
 pub extern fn mrbc_context_free(mrb: *mrb_state, cxt: *mrbc_context) void;
 pub extern fn mrbc_filename(mrb: *mrb_state, cxt: *mrbc_context, s: [*:0]const u8) ?[*:0]const u8;
-pub extern fn mrbc_partial_hook(mrb: *mrb_state, cxt: *mrbc_context, partial_hook: fn (state: *mrb_parser_state) callconv(.C) c_int, data: *anyopaque) void;
+pub extern fn mrbc_partial_hook(mrb: *mrb_state, cxt: *mrbc_context, partial_hook: *const fn (*mrb_parser_state) callconv(.C) c_int, data: *anyopaque) void;
 pub extern fn mrbc_cleanup_local_variables(mrb: *mrb_state, cxt: *mrbc_context) void;
 
 /// AST node structure
@@ -4087,7 +4087,7 @@ pub extern fn mrb_mod_cv_set(mrb: *mrb_state, cla: *RClass, sym: mrb_sym, v: mrb
 pub extern fn mrb_cv_set(mrb: *mrb_state, mod: mrb_value, sym: mrb_sym, v: mrb_value) void;
 pub extern fn mrb_cv_defined(mrb: *mrb_state, mod: mrb_value, sym: mrb_sym) mrb_bool;
 
-pub const mrb_iv_foreach_func = fn (mrb: *mrb_state, sym: mrb_sym, val: mrb_value, ptr: *anyopaque) callconv(.C) c_int;
+pub const mrb_iv_foreach_func = *const fn (mrb: *mrb_state, sym: mrb_sym, val: mrb_value, ptr: *anyopaque) callconv(.C) c_int;
 pub extern fn mrb_iv_foreach(mrb: *mrb_state, obj: mrb_value, func: mrb_iv_foreach_func, ptr: *anyopaque) void;
 
 
@@ -4259,7 +4259,7 @@ pub extern fn mrb_get_backtrace(mrb: *mrb_state) mrb_value;
 pub extern fn mrb_no_method_error(mrb: *mrb_state, id: mrb_sym, args: mrb_value, fmt: [*:0]const u8, ...) mrb_noreturn;
 pub extern fn mrb_f_raise(mrb: *mrb_state, value: mrb_value) mrb_value;
 
-pub const mrb_protect_error_func = fn (mrb: *mrb_state, userdata: *anyopaque) callconv(.C) mrb_value;
+pub const mrb_protect_error_func = *const fn (mrb: *mrb_state, userdata: *anyopaque) callconv(.C) mrb_value;
 
 /// Protect
 pub extern fn mrb_protect_error(mrb: *mrb_state, body: mrb_protect_error_func, userdata: *anyopaque, err: *mrb_bool) mrb_value;
@@ -4460,7 +4460,7 @@ pub extern fn mrb_hash_dup(mrb: *mrb_state, hash: mrb_value) mrb_value;
 pub extern fn mrb_hash_merge(mrb: *mrb_state, hash1: mrb_value, hash2: mrb_value) void;
 
 /// return non zero to break the loop
-pub const mrb_hash_foreach_func = fn (mrb: *mrb_state, key: mrb_value, val: mrb_value, data: *anyopaque) callconv(.C) c_int;
+pub const mrb_hash_foreach_func = *const fn (mrb: *mrb_state, key: mrb_value, val: mrb_value, data: *anyopaque) callconv(.C) c_int;
 pub extern fn mrb_hash_foreach(mrb: *mrb_state, hash: *RHash, func: mrb_hash_foreach_func, ptr: *anyopaque) void;
 
 

--- a/src/mruby.zig
+++ b/src/mruby.zig
@@ -139,7 +139,6 @@ export fn zigMrubyAlloc(mrb: *mrb_state, ptr: ?*anyopaque, size: usize, user_dat
     }
 }
 
-
 /// Create new mrb_state with just the MRuby core
 ///
 /// @param f
@@ -153,7 +152,6 @@ export fn zigMrubyAlloc(mrb: *mrb_state, ptr: ?*anyopaque, size: usize, user_dat
 pub fn open_core(f: mrb_allocf, ud: *anyopaque) !*mrb_state {
     return mrb_open_core(f, ud) orelse error.OpenError;
 }
-
 
 pub const mrb_state = opaque {
     const Self = @This();
@@ -552,7 +550,7 @@ pub const mrb_state = opaque {
 
     /// @see mrb_obj_new
     pub fn class_new_instance(self: *Self, argc: usize, argv: [*]const mrb_value, cla: *RClass) mrb_value {
-      return mrb_class_new_instance(self, argc, argv, cla);
+        return mrb_class_new_instance(self, argc, argv, cla);
     }
 
     /// Creates a new instance of Class, Class.
@@ -2186,7 +2184,7 @@ pub const mrb_ssize = isize;
 pub const mrb_int = isize;
 pub const mrb_uint = usize;
 pub const mrb_float = f64; // HACK: assume 64-bit float for now
-pub const mrb_value = extern struct {  // HACK: assume word boxing for now
+pub const mrb_value = extern struct { // HACK: assume word boxing for now
     w: usize,
 
     const Self = @This();
@@ -2425,12 +2423,12 @@ pub const mrb_value = extern struct {  // HACK: assume word boxing for now
 pub const iv_tbl = opaque {};
 
 pub const mrb_fiber_state = enum(c_int) {
-  MRB_FIBER_CREATED,
-  MRB_FIBER_RUNNING,
-  MRB_FIBER_RESUMED,
-  MRB_FIBER_SUSPENDED,
-  MRB_FIBER_TRANSFERRED,
-  MRB_FIBER_TERMINATED,
+    MRB_FIBER_CREATED,
+    MRB_FIBER_RUNNING,
+    MRB_FIBER_RESUMED,
+    MRB_FIBER_SUSPENDED,
+    MRB_FIBER_TRANSFERRED,
+    MRB_FIBER_TERMINATED,
 };
 
 // Opaque types
@@ -2463,7 +2461,6 @@ pub const RData = opaque {
     pub fn data_type(self: *Self) ?*mrb_data_type {
         return mrb_rdata_type(self);
     }
-
 };
 pub const RInteger = opaque {
     const Self = @This();
@@ -2496,7 +2493,6 @@ pub const RClass = opaque {
     pub fn class_real(self: *Self) ?*Self {
         return mrb_class_real(self);
     }
-
 };
 pub const RProc = opaque {
     const Self = @This();
@@ -2518,7 +2514,6 @@ pub const RArray = opaque {
     pub fn capa(self: *Self) mrb_int {
         return mrb_ary_capa(self);
     }
-
 };
 pub const RHash = opaque {
     const Self = @This();
@@ -2609,7 +2604,6 @@ pub const RRational = opaque {
     }
 };
 
-
 /// Function pointer type for a function callable by mruby.
 ///
 /// The arguments to the function are stored on the mrb_state. To get them see mrb_get_args
@@ -2661,33 +2655,33 @@ pub const mrb_allocf = *const fn (mrb: *mrb_state, ptr: ?*anyopaque, size: usize
 //   f(MRB_TT_RATIONAL,    struct RRational,   "Rational")
 
 pub const mrb_vtype = enum(c_int) {
-  MRB_TT_FALSE,
-  MRB_TT_TRUE,
-  MRB_TT_SYMBOL,
-  MRB_TT_UNDEF,
-  MRB_TT_FREE,
-  MRB_TT_FLOAT,
-  MRB_TT_INTEGER,
-  MRB_TT_CPTR,
-  MRB_TT_OBJECT,
-  MRB_TT_CLASS,
-  MRB_TT_MODULE,
-  MRB_TT_ICLASS,
-  MRB_TT_SCLASS,
-  MRB_TT_PROC,
-  MRB_TT_ARRAY,
-  MRB_TT_HASH,
-  MRB_TT_STRING,
-  MRB_TT_RANGE,
-  MRB_TT_EXCEPTION,
-  MRB_TT_ENV,
-  MRB_TT_DATA,
-  MRB_TT_FIBER,
-  MRB_TT_STRUCT,
-  MRB_TT_ISTRUCT,
-  MRB_TT_BREAK,
-  MRB_TT_COMPLEX,
-  MRB_TT_RATIONAL,
+    MRB_TT_FALSE,
+    MRB_TT_TRUE,
+    MRB_TT_SYMBOL,
+    MRB_TT_UNDEF,
+    MRB_TT_FREE,
+    MRB_TT_FLOAT,
+    MRB_TT_INTEGER,
+    MRB_TT_CPTR,
+    MRB_TT_OBJECT,
+    MRB_TT_CLASS,
+    MRB_TT_MODULE,
+    MRB_TT_ICLASS,
+    MRB_TT_SCLASS,
+    MRB_TT_PROC,
+    MRB_TT_ARRAY,
+    MRB_TT_HASH,
+    MRB_TT_STRING,
+    MRB_TT_RANGE,
+    MRB_TT_EXCEPTION,
+    MRB_TT_ENV,
+    MRB_TT_DATA,
+    MRB_TT_FIBER,
+    MRB_TT_STRUCT,
+    MRB_TT_ISTRUCT,
+    MRB_TT_BREAK,
+    MRB_TT_COMPLEX,
+    MRB_TT_RATIONAL,
 };
 
 /// Defines a new class.
@@ -2972,7 +2966,7 @@ pub extern fn mrb_obj_new(mrb: *mrb_state, cla: *RClass, argc: usize, argv: [*]c
 
 /// @see mrb_obj_new
 pub fn mrb_class_new_instance(mrb: *mrb_state, argc: usize, argv: [*]const mrb_value, cla: *RClass) mrb_value {
-  return mrb_obj_new(mrb,cla,argc,argv);
+    return mrb_obj_new(mrb, cla, argc, argv);
 }
 
 /// Creates a new instance of Class, Class.
@@ -3245,7 +3239,7 @@ pub fn mrb_args_post(n: u5) mrb_aspec {
 
 ///  keyword arguments (n of keys, kdict)
 pub fn mrb_args_key(n1: u5, n2: u5) mrb_aspec {
-    return ((@as(u32, n1) & 0x1f) << 2) | (if (n2 != 0) @as(u8, 1<<1) else 0);
+    return ((@as(u32, n1) & 0x1f) << 2) | (if (n2 != 0) @as(u8, 1 << 1) else 0);
 }
 
 /// Function takes a block argument
@@ -3354,7 +3348,7 @@ pub const mrb_kwargs = extern struct {
     /// keyword argument values
     values: *mrb_value,
     /// keyword rest (dict)
-    rest: *mrb_value
+    rest: *mrb_value,
 };
 
 /// Retrieve arguments from mrb_state.
@@ -3454,7 +3448,6 @@ pub extern fn mrb_funcall_argv(mrb: *mrb_state, val: mrb_value, name: mrb_sym, a
 /// Call existing ruby functions with a block.
 pub extern fn mrb_funcall_with_block(mrb: *mrb_state, val: mrb_value, name: mrb_sym, argc: usize, argv: [*]const *mrb_value, block: mrb_value) mrb_value;
 
-
 /// `strlen` for character string literals (use with caution or `strlen` instead)
 ///  Adjacent string literals are concatenated in C/C++ in translation phase 6.
 ///  If `lit` is not one, the compiler will report a syntax error:
@@ -3548,11 +3541,10 @@ pub extern fn mrb_locale_from_utf81(p: [*]const u8, l: usize) ?[*:0]const u8;
 pub extern fn mrb_locale_free1(p: [*]const u8) void;
 pub extern fn mrb_utf8_free1(p: [*]const u8) void;
 
-
 pub extern fn mrb_obj_freeze(mrb: *mrb_state, val: mrb_value) mrb_value;
-pub fn mrb_str_new_frozen(mrb: *mrb_state, p: [*:0]const u8 , len: mrb_int) mrb_value {
+pub fn mrb_str_new_frozen(mrb: *mrb_state, p: [*:0]const u8, len: mrb_int) mrb_value {
     const value = mrb_str_new(mrb, p, len);
-    return mrb_obj_freeze(mrb,value);
+    return mrb_obj_freeze(mrb, value);
 }
 pub fn mrb_str_new_cstr_frozen(mrb: *mrb_state, p: [*:0]const u8) mrb_value {
     const value = mrb_str_new_cstr(mrb, p);
@@ -3765,11 +3757,9 @@ pub extern fn mrb_show_copyright(mrb: *mrb_state) void;
 
 pub extern fn mrb_format(mrb: *mrb_state, format: [*:0]const u8, ...) mrb_value;
 
-
 /////////////////////////////////////////
 //            mruby/array.h            //
 /////////////////////////////////////////
-
 
 pub const mrb_shared_array = struct {
     redcnt: c_int,
@@ -4009,7 +3999,6 @@ pub extern fn mrb_load_nstring(mrb: *mrb_state, s: [*]const u8, len: usize) mrb_
 pub extern fn mrb_load_string_cxt(mrb: *mrb_state, s: [*:0]const u8, cxt: *mrbc_context) mrb_value;
 pub extern fn mrb_load_nstring_cxt(mrb: *mrb_state, s: [*]const u8, len: usize, cxt: *mrbc_context) mrb_value;
 
-
 ////////////////////////////////////////////
 //            mruby/variable.h            //
 ////////////////////////////////////////////
@@ -4090,7 +4079,6 @@ pub extern fn mrb_cv_defined(mrb: *mrb_state, mod: mrb_value, sym: mrb_sym) mrb_
 pub const mrb_iv_foreach_func = *const fn (mrb: *mrb_state, sym: mrb_sym, val: mrb_value, ptr: *anyopaque) callconv(.C) c_int;
 pub extern fn mrb_iv_foreach(mrb: *mrb_state, obj: mrb_value, func: mrb_iv_foreach_func, ptr: *anyopaque) void;
 
-
 /////////////////////////////////////////
 //            mruby/value.h            //
 /////////////////////////////////////////
@@ -4152,14 +4140,12 @@ pub extern fn mrb_get_true_value() mrb_value;
 pub extern fn mrb_get_bool_value(boolean: mrb_bool) mrb_value;
 pub extern fn mrb_get_undef_value() mrb_value;
 
-
 /////////////////////////////////////////////////
 //            mruby/<boxing_type>.h            //
 /////////////////////////////////////////////////
 
-
 pub extern fn mrb_integer_func(o: mrb_value) mrb_int;
-pub extern fn mrb_get_type(o:mrb_value) mrb_vtype;
+pub extern fn mrb_get_type(o: mrb_value) mrb_vtype;
 // hacks
 pub extern fn mrb_get_ptr(v: mrb_value) *anyopaque;
 pub extern fn mrb_get_cptr(v: mrb_value) *anyopaque;
@@ -4197,8 +4183,6 @@ pub extern fn mrb_get_istruct_p(o: mrb_value) mrb_bool;
 pub extern fn mrb_get_break_p(o: mrb_value) mrb_bool;
 pub extern fn mrb_get_immediate_p(o: mrb_value) mrb_bool;
 
-
-
 /////////////////////////////////////////
 //            mruby/class.h            //
 /////////////////////////////////////////
@@ -4213,10 +4197,8 @@ pub extern fn mrb_class_real(cl: *RClass) ?*RClass;
 // hack
 pub extern fn mrb_get_class(mrb: *mrb_state, v: mrb_value) ?*RClass;
 
-
 // pub const mrb_mt_foreach_func = fn (mrb: *mrb_state, sym: mrb_sym, method: mrb_method_t, data: *anyopaque) c_int;
 // pub extern fn mrb_mt_foreach(mrb: *mrb_state, cla: *RClass, func: *mrb_mt_foreach_func, data: *anyopaque) void;
-
 
 ////////////////////////////////////////
 //            mruby/data.h            //
@@ -4239,7 +4221,6 @@ pub fn mrb_rdata(obj: mrb_value) ?*RData {
 }
 pub extern fn mrb_rdata_data(data: *RData) ?*anyopaque;
 pub extern fn mrb_rdata_type(data: *RData) ?*const mrb_data_type;
-
 
 /////////////////////////////////////////
 //            mruby/error.h            //
@@ -4463,18 +4444,17 @@ pub extern fn mrb_hash_merge(mrb: *mrb_state, hash1: mrb_value, hash2: mrb_value
 pub const mrb_hash_foreach_func = *const fn (mrb: *mrb_state, key: mrb_value, val: mrb_value, data: *anyopaque) callconv(.C) c_int;
 pub extern fn mrb_hash_foreach(mrb: *mrb_state, hash: *RHash, func: mrb_hash_foreach_func, ptr: *anyopaque) void;
 
-
 ////////////////////////////////////////
 //            mruby/irep.h            //
 ////////////////////////////////////////
 
 pub const irep_pool_type = enum(c_int) {
-    IREP_TT_STR   = 0,          // string (need free)
-    IREP_TT_SSTR  = 2,          // string (static)
-    IREP_TT_INT32 = 1,          // 32bit integer
-    IREP_TT_INT64 = 3,          // 64bit integer
-    IREP_TT_BIGINT = 7,         // big integer (not yet supported)
-    IREP_TT_FLOAT = 5,          // float (double/float)
+    IREP_TT_STR = 0, // string (need free)
+    IREP_TT_SSTR = 2, // string (static)
+    IREP_TT_INT32 = 1, // 32bit integer
+    IREP_TT_INT64 = 3, // 64bit integer
+    IREP_TT_BIGINT = 7, // big integer (not yet supported)
+    IREP_TT_FLOAT = 5, // float (double/float)
 };
 
 pub const mrb_pool_value = opaque {};
@@ -4486,8 +4466,8 @@ pub const mrb_catch_type = enum(u8) {
 
 pub const mrb_irep_catch_handler = extern struct {
     catch_type: mrb_catch_type,
-    begin: [4]u8,  // The starting address to match the handler. Includes this.
-    end: [4]u8,    // The endpoint address that matches the handler. Not Includes this.
+    begin: [4]u8, // The starting address to match the handler. Includes this.
+    end: [4]u8, // The endpoint address that matches the handler. Not Includes this.
     target: [4]u8, // The address to jump to if a match is made.
 };
 
@@ -4495,9 +4475,9 @@ pub const mrb_irep_debug_info = opaque {};
 
 /// Program data array struct
 pub const mrb_irep = extern struct {
-    nlocals: u16,        // Number of local variables
-    nregs: u16,          // Number of register variables
-    clen: u16,           // Number of catch handlers
+    nlocals: u16, // Number of local variables
+    nregs: u16, // Number of register variables
+    clen: u16, // Number of catch handlers
     flags: u16,
 
     iseq: [*]const mrb_code,
@@ -4542,7 +4522,6 @@ pub extern fn mrb_load_irep_cxt(mrb: *mrb_state, irep_code: [*]const u8, context
 /// @param [const void*] irep code
 /// @param [size_t] size of irep buffer.
 pub extern fn mrb_load_irep_buf_cxt(mrb: *mrb_state, irep_code: *const anyopaque, size: usize, context: *mrbc_context) mrb_value;
-
 
 ///////////////////////////////////////////
 //            mruby/numeric.h            //
@@ -4591,10 +4570,10 @@ pub extern fn mrb_range_ptr(mrb: *mrb_state, range: mrb_value) ?*RRange;
 ///
 pub extern fn mrb_range_new(mrb: *mrb_state, start: mrb_value, end: mrb_value, exclude: mrb_bool) mrb_value;
 
-pub const mrb_range_beg_len_t = enum (c_int) {
-  MRB_RANGE_TYPE_MISMATCH = 0,  // (failure) not range
-  MRB_RANGE_OK = 1,             // (success) range
-  MRB_RANGE_OUT = 2             // (failure) out of range
+pub const mrb_range_beg_len_t = enum(c_int) {
+    MRB_RANGE_TYPE_MISMATCH = 0, // (failure) not range
+    MRB_RANGE_OK = 1, // (success) range
+    MRB_RANGE_OUT = 2, // (failure) out of range
 };
 
 pub extern fn mrb_range_beg_len(mrb: *mrb_state, range: mrb_value, begp: *mrb_int, lenp: *mrb_int, len: mrb_int, trunc: mrb_bool) mrb_range_beg_len_t;
@@ -4602,9 +4581,7 @@ pub extern fn mrb_range_beg1(mrb: *mrb_state, range: mrb_value) mrb_value;
 pub extern fn mrb_range_end1(mrb: *mrb_state, range: mrb_value) mrb_value;
 pub extern fn mrb_range_excl_p1(mrb: *mrb_state, range: mrb_value) mrb_bool;
 
-
 // mruby/string.h
-
 
 pub extern fn mrb_str_modify(mrb: *mrb_state, s: *RString) void;
 /// mrb_str_modify() with keeping ASCII flag if set


### PR DESCRIPTION
Thanks for the project! 🙇 

## Changes
- update Zig to `v0.11.0`:
  - update signature of `addMruby`, in order to pass the `allocator` from the build.
  - remove reference to adding framework `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk`
    - I also got this error on a previous version of OSX, but this works fine for me without it on Ventura 13.4
  - remove `-ffast-math`, as I didn't have this issue locally
  - update `build.zig` to newer `std.Build` syntax
  - change `@call(.{},` to `@call(.auto,`
  - add `*const` to some c function pointers
  - `zig fmt` changes
- add Github Actions CI, using Zig `0.11.0-dev.3289+16dbb960f`
  - You'll need to merge this before the actions show up on this repo, but it runs [successfully on my fork](https://github.com/jethrodaniel/mruby-zig/actions/runs/5107816250).
  - (after this, you should probably also enable status check requirements for merging PRs in Github settings)