### PR TITLE
Allow depending on mruby build, support passing args to rake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-out
 zig-cache
+*.mrb

--- a/README.md
+++ b/README.md
@@ -28,7 +28,26 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     b.installArtifact(exe);
-    const build_mruby_step = addMruby(b, exe);
+
+    // Run default rake task
+    const build_mruby_step = addMruby(b, exe, &.{});
+
+    // Add options to rake
+    // const build_mruby_step = addMruby(b, exe, &.{"--verbose"});
+
+    // Run specific tasks
+    // const build_mruby_step = addMruby(b, exe, &.{
+    //   "all",
+    //   "test",
+    // });
+
+    // Use a specific `build_config.rb`
+    // const relative_root_dir = std.fs.path.dirname(@src().file) orelse ".";
+    // const root_dir = std.fs.realpathAlloc(b.allocator, relative_root_dir) catch @panic("realpathAlloc");
+    // const config_path = std.fs.path.join(b.allocator, &.{ //
+    //     root_dir, "src", "build_config.rb",
+    // }) catch unreachable;
+    // build_mruby_step.setEnvironmentVariable("MRUBY_CONFIG", config_path);
 
     // ...
 }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     b.installArtifact(exe);
-    addMruby(b, exe);
+    const build_mruby_step = addMruby(b, exe);
 
     // ...
 }

--- a/examples/bytecode.rb
+++ b/examples/bytecode.rb
@@ -1,0 +1,1 @@
+puts "Hello from compiled bytecode!"

--- a/examples/main.zig
+++ b/examples/main.zig
@@ -30,6 +30,10 @@ pub fn main() anyerror!void {
     // Loading a program from file
     _ = try mrb.load_file("examples/hello.rb");
 
+    // Loading a program from bytecode
+    const mruby_bytecode = @ptrCast([*]const u8, @embedFile("bytecode.mrb"));
+    _ = mrb.load_irep(mruby_bytecode);
+
     // Adding a zig function to ruby
     const kptr = mrb.kernel_module();
     const kval = kptr.value();

--- a/src/mruby.zig
+++ b/src/mruby.zig
@@ -2583,10 +2583,10 @@ pub const RBreak = opaque {
         return mrb_break_proc_set1(self, proc);
     }
     pub fn tag_get(self: *Self) rbreak_tag {
-        return mrb_break_tag_get1(self);
+        return mrb_break_tag_get(self);
     }
     pub fn tag_set(self: *Self, tag: rbreak_tag) void {
-        return mrb_break_tag_set1(self, tag);
+        return mrb_break_tag_set(self, tag);
     }
 };
 pub const RComplex = opaque {
@@ -4281,8 +4281,8 @@ pub extern fn mrb_break_value_get1(brk: *RBreak) mrb_value;
 pub extern fn mrb_break_value_set1(brk: *RBreak, val: mrb_value) void;
 pub extern fn mrb_break_proc_get1(brk: *RBreak) ?*const RProc;
 pub extern fn mrb_break_proc_set1(brk: *RBreak, proc: *RProc) void;
-pub extern fn mrb_break_tag_get1(brk: *RBreak) rbreak_tag;
-pub extern fn mrb_break_tag_set1(brk: *RBreak, tag: rbreak_tag) void;
+pub extern fn mrb_break_tag_get(brk: *RBreak) rbreak_tag;
+pub extern fn mrb_break_tag_set(brk: *RBreak, tag: rbreak_tag) void;
 
 // TODO: gc.h functions
 

--- a/src/mruby_compat.c
+++ b/src/mruby_compat.c
@@ -330,10 +330,10 @@ const struct RProc *mrb_break_proc_get1(struct RBreak *brk) {
 void mrb_break_proc_set1(struct RBreak *brk, struct RProc *proc) {
     mrb_break_proc_set(brk, proc);
 }
-uint32_t mrb_break_tag_get1(struct RBreak *brk) {
+uint32_t mrb_break_tag_get(struct RBreak *brk) {
     return mrb_break_tag_get(brk);
 }
-void mrb_break_tag_set1(struct RBreak *brk, uint32_t tag) {
+void mrb_break_tag_set(struct RBreak *brk, uint32_t tag) {
     return mrb_break_tag_set(brk, tag);
 }
 


### PR DESCRIPTION
## Changes
- update `addMruby` to return a build step users can use to ensure `rake` has already been ran
  - update example to include embedding bytecode produced by `mrbc` using `@embedFile`
  - Also supports passing in arguments to `rake` directly
  - **NOTE**: this PR targets https://github.com/dantecatalfamo/mruby-zig/pull/4, which in turn targets https://github.com/dantecatalfamo/mruby-zig/pull/3